### PR TITLE
fix: fix various typos and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Here's an image of the QR code you can use to log in to the application from a l
 
 The `docker-compose.yml` file and the `kickstart` directory are used to start and configure a local FusionAuth server.
 
-The `/complete-application` directory contains a fully working version of the application.
-
 ## Project Dependencies
 * Docker, for running FusionAuth
 * Python 3.8 or later, for running the Changebank Python application
@@ -71,10 +69,10 @@ With the ngrok command output above, it would look like this:
     "app_url": "https://9184-73-249-72-110.ngrok-free.app",
 ```
 
-Then, to run FusionAuth, stand up the docker containers using `docker-compose`.
+Then, to run FusionAuth, stand up the docker containers using `docker compose`.
 
 ```shell
-docker-compose up
+docker compose up -d
 ```
 
 This will start a PostgreSQL database, and Elastic service, and the FusionAuth server.

--- a/server.py
+++ b/server.py
@@ -31,7 +31,6 @@ oauth.register(
   client_id=env.get("CLIENT_ID"),
   client_secret=env.get("CLIENT_SECRET"),
   client_kwargs={
-  ##  'verify': False,
     "scope": "openid email profile offline_access",
     'code_challenge_method': 'S256' # This enables PKCE
   },
@@ -40,22 +39,18 @@ oauth.register(
 
 client = FusionAuthClient("apikeynotneeded", env.get("ISSUER"))
 
-#tag::pollingSetup[]
+#tag::pollUrl[]
 polling_data = {'content': '', 'code': '', 'interval': 5}
 polling_lock = threading.Lock()
 stop_event = threading.Event()
 polling_thread = None
-#end::pollingSetup[]
 
 #tag::pollUrl[]
 def poll_url(stop_event):
-    #print("starting polling")
     while not stop_event.is_set():
         with polling_lock:
             interval = polling_data['interval']
         try:
-            #print("in polling loop")
-            #print(polling_data['code'])
             data = {
               "client_id": env.get("CLIENT_ID"),
               "device_code": polling_data['code'],
@@ -63,12 +58,8 @@ def poll_url(stop_event):
             }
 
             device_token_url = env.get("ISSUER")+'/oauth2/token'
-            #print("polling token endpoint")
-            #print(device_token_url)
             response = requests.post(device_token_url, headers={},data=data)
-            #print(response.json())
             if response.status_code == 200:
-              #print("request posted")
               polling_data['content'] = response.json()
         except Exception as e:
             polling_data['content'] = f"Error: {e}"
@@ -92,13 +83,11 @@ def home():
 #tag::deviceGrantFinished[]
 @app.route("/device_grant_finished")
 def device_grant_finished():
-    #print("device_grant_finished")
     content = ""
     with polling_lock:
       content = polling_data['content']
     try:
       if content != "":
-        #print("returning reload signal, stopping polling")
         stop_event.set() 
         if polling_thread != None:
           polling_thread.join()  # Wait for the thread to finish
@@ -113,7 +102,6 @@ def device_grant_finished():
 #tag::reload[]
 @app.route("/reload")
 def reload():
-    #print("reload")
     content = ""
     with polling_lock:
       content = polling_data['content']
@@ -131,7 +119,7 @@ def reload():
       content = ""
     # something has gone awry, but lets just send the user to / anyway. they won't be logged in
     return make_response(redirect("/"))
-#end::loginRoute[]
+#end::reload[]
 
 #tag::loginRoute[]
 @app.route("/login")
@@ -204,14 +192,11 @@ def logged_out_qr_login():
   }
   response = requests.post(device_start_url,headers={},data=data)
   verification_url_complete = response.json()['verification_uri_complete']
-  #print(verification_url_complete)
   device_code = response.json()['device_code']
-  #print(device_code)
 
   with polling_lock:
     polling_data['code'] = device_code
   try:
-    #print("in lock")
     print(polling_data['code'])
   except Exception as e:
     print(f"Error: {e}")
@@ -264,7 +249,7 @@ def make_change():
     logoutUrl=get_logout_url())
 #end::makeChangeRoute[]
 
-
+#tag::process_token[]
 def process_token(token, resp):
 
   resp.set_cookie(ACCESS_TOKEN_COOKIE_NAME, token["access_token"], max_age=token["expires_in"], httponly=True, samesite="Lax")
@@ -273,7 +258,7 @@ def process_token(token, resp):
   session["user"] = token["userinfo"]
 
   return resp
+#end::process_token[]
 
 if __name__ == "__main__":
   app.run(host="0.0.0.0", port=env.get("PORT", 5000))
-

--- a/templates/home.html
+++ b/templates/home.html
@@ -27,7 +27,7 @@
           <div style="margin-bottom: 100px;">
             <h1>Welcome to Changebank</h1>
             <p>To get started, <a href="/login">log in or create a new account</a>.</p>
-            <p>If you are logged in on your mobil device, you can <a href="/logged-out-qr-login">log in</a> using that too.</p>
+            <p>If you are logged in on your mobile device, you can <a href="/logged-out-qr-login">log in</a> using that too.</p>
           </div>
         </div>
         <div style="flex: 0;">


### PR DESCRIPTION
### Problems

* The README refers to a `/complete-application` dir that doesn't exist.
* The `docker compose` command in the README contains a typo.
* `server.py` contains several commented-out print statements.
* The polling logic in `server.py` is separated into the `pollingSetup` and `pollUrl` tags. However, these are typically displayed together when reused in the docs.
* The `reload` tag in `server.py` is not closed.
* The `process_token` function has no tag and can't be reused in the docs.
* The `/home.html` template contains a typo (`mobil`)

### Solutions

Fixes the above problems.